### PR TITLE
Get expand.dft and expand.table to work with tibbles

### DIFF
--- a/R/expand.dft.R
+++ b/R/expand.dft.R
@@ -12,7 +12,7 @@ expand.dft <- function(x, var.names = NULL, freq = "Freq", ...)
       stop(paste(sQuote("freq"), "not found in column names"))
 
   DF <- sapply(1:nrow(x),
-               function(i) x[rep(i, each = x[i, freq.col]), ],
+               function(i) x[rep(i, each = x[i, freq.col, drop = TRUE]), ],
                simplify = FALSE)
 
   DF <- do.call("rbind", DF)[, -freq.col, drop=FALSE]


### PR DESCRIPTION
Issue https://github.com/friendly/vcdExtra/issues/4 describes how `expand.table` fails on tibbles.  This is due to the non-standard behaviour of tibbles when subsetting to a single element:  matrices and dataframes extract the value, tibbles return a 1x1 tibble.  However, all three behave the same if `drop = TRUE` is specified, which is what this patch does.

This appears to be the only case within `vcdExtra` of the use of an expression of the form `x[i,j]` where `x` could possibly be a tibble, so it should cover all cases.  However, I have not checked all the packages from which `vcdExtra` imports functions, so it may well be that some functions still expect objects with class `"data.frame"` to behave the way dataframes do.