### PR TITLE
Fix datasets() issue #6

### DIFF
--- a/man/Cormorants.Rd
+++ b/man/Cormorants.Rd
@@ -48,26 +48,28 @@ Unpublished MA project, Environmental Studies, York University.
 data(Cormorants)
 str(Cormorants)
 
-library(ggplot2)
-ggplot(Cormorants, aes(count)) + geom_histogram(binwidth=0.5) + 
-	labs(x="Number of birds advertising")
+if (require("ggplot2")) {
+  print(ggplot(Cormorants, aes(count)) + geom_histogram(binwidth=0.5) + 
+	  labs(x="Number of birds advertising"))
 
 # Quick look at the data, on the log scale, for plots of `count ~ week`, 
 #   stratified by something else.
-library(ggplot2)
-ggplot(Cormorants, aes(week, count, color=height)) + geom_jitter() +
-	stat_smooth(method="loess", size=2) + scale_y_log10(breaks=c(1,2,5,10)) +
-	geom_vline(xintercept=c(4.5, 9.5))
+
+  print(ggplot(Cormorants, aes(week, count, color=height)) + geom_jitter() +
+	  stat_smooth(method="loess", size=2) + scale_y_log10(breaks=c(1,2,5,10)) +
+	  geom_vline(xintercept=c(4.5, 9.5)))
+}
 
 # ### models using week 
 fit1 <-glm(count ~ week + station + nest + height + density + tree_health, data=Cormorants,
     family =  poisson)
 
-library(car)
-Anova(fit1)
+if (requireNamespace("car"))
+  car::Anova(fit1)
+  
 # plot fitted effects
-library(effects)
-plot(allEffects(fit1))
+if (requireNamespace("effects"))
+  plot(effects::allEffects(fit1))
 
 }
 \keyword{datasets}


### PR DESCRIPTION
This PR contains two changes.  The more important one is to datasets.R:  it allows the datasets() function to work with packages that don't have `LazyData: TRUE`.  In doing this, it makes two other changes:  

    - it doesn't attach the named packages; that's up to the user to ask to do if s/he wants.
    - it doesn't modify the names of items that are grouped, e.g. "BJsales.lead (BJsales)" will be displayed that way.

The second change was to avoid some check problems:  the Cormorants example assumed some suggested packages were available; now it protects against errors if they are not.